### PR TITLE
Avoid java.net.URI's RFC 2396 parsing to allow more modern URLs

### DIFF
--- a/app/src/main/java/com/github/apognu/otter/utils/Util.kt
+++ b/app/src/main/java/com/github/apognu/otter/utils/Util.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import com.google.android.exoplayer2.util.Log
 import com.preference.PowerPreference
 import java.net.URI
+import java.net.URL
 
 fun Context?.toast(message: String, length: Int = Toast.LENGTH_SHORT) {
   if (this != null) {
@@ -20,23 +21,18 @@ fun Any.log() {
   Log.d("FUNKWHALE", this.toString())
 }
 
-fun maybeNormalizeUrl(url: String?): String? {
-  if (url == null || url.isEmpty()) return null
+fun maybeNormalizeUrl(rawUrl: String?): String? {
+  if (rawUrl == null || rawUrl.isEmpty()) return null
 
-  val fallbackHost = PowerPreference.getFileByName(AppContext.PREFS_CREDENTIALS).getString("hostname")
-  val uri = URI(url).takeIf { it.host != null } ?: URI("$fallbackHost$url")
-
-  return uri.run {
-    URI("https", host, path, query, null)
-  }.toString()
+  return mustNormalizeUrl(rawUrl)
 }
 
-fun mustNormalizeUrl(url: String): String {
+fun mustNormalizeUrl(rawUrl: String): String {
   val fallbackHost = PowerPreference.getFileByName(AppContext.PREFS_CREDENTIALS).getString("hostname")
-  val uri = URI(url).takeIf { it.host != null } ?: URI("$fallbackHost$url")
+  val uri = URI(rawUrl).takeIf { it.host != null } ?: URI("$fallbackHost$rawUrl")
 
-  return uri.run {
-    URI("https", host, path, query, null)
+  return uri.toURL().run {
+    URL("https", host, file)
   }.toString()
 }
 


### PR DESCRIPTION
When using Funkwhale with music hosted in Digital Ocean Spaces (and likely some other S3-compatible services), links to the files are returned that may contain query arguments with escaped characters (such as %20).

However, `java.net.URI` strictly adheers to the outdated RFC 2396 URI spec, and interprets but does not re-escape these characters when parts are fetched via any of its 'get' methods. This causes some URI's to become invalid when using the modern specs (RFC 3986 and newer), as the character set allowed in any are much more strict. 

To avoid this, we instead convert to the URL class (which does not perform any conversions, just parses). Additionally, I removed the re-implimentation between maybeNormalizeUrl and mustNormalizeUrl

At least, AFAIK, I'm no RFC knowledge base - however, this patch does indeed solve the interpretation of escaped characters in the URLs that breaks my instance. Let me know what you think :)