### PR TITLE
[WIP] Basic Android Auto support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.github.apognu.otter">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.github.apognu.otter">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -15,6 +16,13 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppTheme">
+
+    <meta-data
+        android:name="com.google.android.gms.car.notification.SmallIcon"
+        android:resource="@drawable/ottershape" />
+    <meta-data android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc"/>
+
 
     <!-- <meta-data
       android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
@@ -44,7 +52,14 @@
     <activity android:name="com.github.apognu.otter.activities.SettingsActivity" />
     <activity android:name="com.github.apognu.otter.activities.LicencesActivity" />
 
-    <service android:name="com.github.apognu.otter.playback.PlayerService" />
+    <service
+        android:name="com.github.apognu.otter.playback.PlayerService"
+        android:exported="true"
+        tools:ignore="ExportedService">
+      <intent-filter>
+        <action android:name="android.media.browse.MediaBrowserService"/>
+      </intent-filter>
+    </service>
 
     <service
       android:name=".playback.PinService"

--- a/app/src/main/java/com/github/apognu/otter/playback/PlayerService.kt
+++ b/app/src/main/java/com/github/apognu/otter/playback/PlayerService.kt
@@ -1,7 +1,6 @@
 package com.github.apognu.otter.playback
 
 import android.annotation.SuppressLint
-import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -9,10 +8,13 @@ import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
-import android.os.IBinder
+import android.os.Bundle
+import android.support.v4.media.MediaBrowserCompat
+import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.view.KeyEvent
 import com.github.apognu.otter.Otter
+import androidx.media.MediaBrowserServiceCompat
 import com.github.apognu.otter.R
 import com.github.apognu.otter.utils.*
 import com.google.android.exoplayer2.C
@@ -30,7 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
-class PlayerService : Service() {
+class PlayerService : MediaBrowserServiceCompat() {
   private lateinit var queue: QueueManager
   private val jobs = mutableListOf<Job>()
 
@@ -83,6 +85,8 @@ class PlayerService : Service() {
     mediaSession = MediaSessionCompat(this, applicationContext.packageName).apply {
       isActive = true
     }
+
+    sessionToken = mediaSession.sessionToken
 
     mediaControlsManager = MediaControlsManager(this, mediaSession)
 
@@ -223,8 +227,6 @@ class PlayerService : Service() {
       }
     })
   }
-
-  override fun onBind(intent: Intent?): IBinder? = null
 
   @SuppressLint("NewApi")
   override fun onDestroy() {
@@ -436,5 +438,21 @@ class PlayerService : Service() {
         }
       }
     }
+  }
+
+  override fun onGetRoot(
+    clientPackageName: String,
+    clientUid: Int,
+    rootHints: Bundle?
+  ): BrowserRoot? {
+    return BrowserRoot("/", null)
+  }
+
+  override fun onLoadChildren(
+    parentId: String,
+    result: Result<List<MediaBrowserCompat.MediaItem>>
+  ) {
+    val list = mutableListOf<MediaBrowserCompat.MediaItem>()
+    result.sendResult(list)
   }
 }

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
Implement very basic Android Auto support, relying on ExoPlayer builtins such as [MediaSessionConnector](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/ext/mediasession/MediaSessionConnector.html) and [TimelineQueueNavigator](https://github.com/google/ExoPlayer/blob/release-v2/extensions/mediasession/src/main/java/com/google/android/exoplayer2/ext/mediasession/TimelineQueueNavigator.java) as much as possible to avoid introducing unnecessary complexity into the app.

Closes #12 

Feature hitlist:
- [x] View playback state and current track from Android Auto
- [x] Transport (forward, back) controls
- [x] View / jump in Queue 
- [ ] Browse library

Bugs that need resolved:
- [ ] Automatically switch to correct output
- [ ] Avoid duplicate new track notification when fetching next track